### PR TITLE
added a short description to each prototype

### DIFF
--- a/docs/Prototype/user-guide.md
+++ b/docs/Prototype/user-guide.md
@@ -10,6 +10,17 @@ Prototype builder generates:
   * **Actions** (a.k.a. controllers)
   * Initial **database** (configuration, admin user)
 
+### Descriptions of each of the prototype examples
+
+1. [01-one-widget.json](examples/01-one-widget.json) - shows a basic CRM application with a dashboard and no additional database tables created
+2. [02-customers-data-model.json](examples/02-customers-data-model.json) - in addition to the previous prototype, also creates a database table with customers that have a name and a priority
+3. [03-customized-form.json](examples/03-customized-form.json) - creates a database of customers similar to the previous prototype but with the addition of best-selling products and monthly turnover statistics for each customer
+4. [04-second-model-in-a-widget.json](examples/04-second-model-in-a-widget.json) - creates a database of customers, best-selling products and monthly turnover statistics for each customer and allows you to add bids to each customer
+5. [05-nested-table-in-a-form.json](examples/05-nested-table-in-a-form.json) - similar to the previous prototype but adds the ability to view a customer's bids by viewing their settings
+6. [06-widget-for-settings.json](examples/06-widget-for-settings.json) - 
+7. [07-customer-categories-cross-table.json](examples/07-customer-categories-cross-table.json) - creates a database of all customers, their bids and categories, which you can add customers to
+8. [10-simple-crm.json](examples/10-simple-crm.json) - creates a complete CRM showcase of what ADIOS can do, including tables for customers, customer bids, categories, plus settings and a calendar (work in progress)
+
 ## Steps
 
 1. Create your project folder (a "ROOT_DIR").
@@ -17,7 +28,7 @@ Prototype builder generates:
 3. Run `composer install`
 4. Create a prototype.json file in the ROOT_DIR (see [examples](examples)).
 5. Run: `php vendor/wai-blue/adios/src/CLI/build-prototype.php -I prototype.json -A vendor/autoload` from the ROOT_DIR.
-6. In a browser, launch install.php script whic is now in the ROOT_DIR folder (the file was created by the prototype builder). If you use localhost, it may be something like http://localost/your_project/install.php.
+6. In a browser, launch install.php script which is now in the ROOT_DIR folder (the file was created by the prototype builder). If you use localhost, it may be something like http://localost/your_project/install.php.
 7. Log in as administrator. Login and password are shown in the browser.
 
 ## Shell script examples


### PR DESCRIPTION
Spravil som nejaký zoznam príkladových prototypov a dopísal som k ním, čo každý robí/ukazuje. 

- K 10 som dopísal, že je WIP, nakoľko mi nefungovali tie samotné widgety Settings a Calendar v sidebare a ani som nenašiel dané templaty v súboroch. 
- 6ka a vlastne settingy v každom ďalšom prototype mi hádzali error, celé znenie som prilepil dole, ďalej som sa s tým nezapodieval, aby som sa tam nezasekol. Dialo sa to aj s Basic aj s Extended. Takže by možno bolo treba ešte dopísať, že čo tie settingy robia.
- Na začiatku mi to hádzalo ďalšie deprecated warningy, tie ma celkom zdržali, keďže mi kvôli nim nefungoval ani login systém (header() funkcia ma nechcela presmerovať, kým tam boli, takže ich trebalo skryť). Fix na Eloquent/Builder.php zo včera nezabral. Dočasne som to vyriešil tak, že som ich skryl v src/Init.php, ale asi sa na ne bude treba pozrieť. Dal som ich na tento [paste](https://paste.bingner.com/paste/dgp32). Môžem to dať aj do troubleshooting.md ak treba, ale nepríde mi to ako plnohodnotné riešenie :D

`PHP Fatal error: Cannot declare class ADIOS\\Actions\\Settings\\Basic, because the name is already in use in /home/gopes/PhpstormProjects/prototype_crm/src/Widgets/Settings/Actions/Basic.php on line 5, referer: http://localhost/prototype_crm/`