### PR TITLE
Dispatch - requests to the world wide web

### DIFF
--- a/src/Components/Dispatch.tsx
+++ b/src/Components/Dispatch.tsx
@@ -1,0 +1,117 @@
+import React, { Component } from 'react';
+import axios, { AxiosError, AxiosResponse } from "axios";
+import ApiError from './Request';
+import ApiResponse from './Request';
+
+class Dispatch {
+
+
+  public get<T>(
+    url: string,
+    queryParams: Record<string, any>,
+    successCallback?: (data: ApiResponse<T>) => void,
+    errorCallback?: (data: any) => void,
+  ): void {
+    document.body.classList.add("ajax-loading");
+    axios.get<T, AxiosResponse<ApiResponse<T>>>(url, {
+      params: queryParams
+    }).then(res => {
+      const responseData: ApiResponse<T> = res.data;
+      document.body.classList.remove("ajax-loading");
+      if (successCallback) successCallback(responseData);
+    }).catch((err: AxiosError<ApiError>) => this.catchHandler(url, err, errorCallback));
+  }
+
+  public post<T>(
+    url: string,
+    postData: Record<string, any>,
+    queryParams?: Record<string, string>|{},
+    successCallback?: (data: ApiResponse<T>) => void,
+    errorCallback?: (data: any) => void,
+  ): void {
+    document.body.classList.add("ajax-loading");
+    axios.post<T, AxiosResponse<ApiResponse<T>>>(url, postData, {
+      params: queryParams
+    }).then(res => {
+      const responseData: ApiResponse<T> = res.data;
+      document.body.classList.remove("ajax-loading");
+      if (successCallback) successCallback(responseData);
+    }).catch((err: AxiosError<ApiError>) => this.catchHandler(url, err, errorCallback));
+  }
+
+  public put<T>(
+    url: string,
+    putData: Record<string, any>,
+    queryParams?: Record<string, string>|{},
+    successCallback?: (data: ApiResponse<T>) => void,
+    errorCallback?: (data: any) => void,
+  ): void {
+    axios.put<T, AxiosResponse<ApiResponse<T>>>(url, putData, {
+      params: queryParams
+    }).then(res => {
+      const responseData: ApiResponse<T> = res.data;
+      if (successCallback) successCallback(responseData);
+    }).catch((err: AxiosError<ApiError>) => this.catchHandler(url, err, errorCallback));
+  }
+
+  public patch<T>(
+    url: string,
+    patchData: Record<string, any>,
+    queryParams?: Record<string, string>|{},
+    successCallback?: (data: ApiResponse<T>) => void,
+    errorCallback?: (data: any) => void,
+  ): void {
+    axios.patch<T, AxiosResponse<ApiResponse<T>>>(url, patchData, {
+      params: queryParams
+    }).then(res => {
+      const responseData: ApiResponse<T> = res.data;
+      if (successCallback) successCallback(responseData);
+    }).catch((err: AxiosError<ApiError>) => this.catchHandler(url, err, errorCallback));
+  }
+
+  public delete<T>(
+    url: string,
+    queryParams: Record<string, any>,
+    successCallback?: (data: ApiResponse<T>) => void,
+    errorCallback?: (data: any) => void,
+  ): void {
+    axios.delete<T, AxiosResponse<ApiResponse<T>>>(url, {
+      params: queryParams
+    }).then(res => {
+      const responseData: ApiResponse<T> = res.data;
+      if (successCallback) successCallback(responseData);
+    }).catch((err: AxiosError<ApiError>) => this.catchHandler(url, err, errorCallback));
+  }
+
+  private catchHandler(
+    url: string,
+    err: AxiosError<ApiError>,
+    errorCallback?: (data: any) => void
+  ) {
+    if (err.response) {
+      if (err.response.status == 500) {
+        this.fatalErrorNotification(err.response.data);
+      } else {
+        this.fatalErrorNotification(err.response.data);
+        console.error('ADIOS: ' + err.code, err.config?.url, err.config?.params, err.response.data);
+        if (errorCallback) errorCallback(err.response);
+      }
+    } else {
+      console.error('ADIOS: Dispatch @ ' + url + ' unknown error.');
+      console.error(err);
+      this.fatalErrorNotification("Unknown error");
+    }
+  }
+
+  private fatalErrorNotification(error: any) {
+    if (typeof error == 'string') {
+      globalThis.app.showDialogDanger(error);
+    } else {
+      globalThis.app.showDialogDanger(globalThis.app.makeErrorResultReadable(error));
+    }
+  }
+
+}
+
+const dispatch = new Dispatch();
+export default dispatch;


### PR DESCRIPTION
Dispatch.tsx is basically just a adjusted copy without accountUrl index, so it allows requests to anywhere on whats reachable on the internet.

Copilot summary below.

This pull request introduces a new `Dispatch` class in `src/Components/Dispatch.tsx` to handle various HTTP request methods using the `axios` library. The class includes methods for `GET`, `POST`, `PUT`, `PATCH`, and `DELETE` requests, as well as error handling and notification mechanisms.

Key changes:

* **HTTP Request Methods**:
  - Implemented `get`, `post`, `put`, `patch`, and `delete` methods to handle respective HTTP requests using `axios`. These methods include success and error callback handling.

* **Error Handling**:
  - Added a private `catchHandler` method to manage errors from `axios` requests, including logging and invoking error callbacks.
  - Introduced a private `fatalErrorNotification` method to display error notifications using the global `app` object.

* **Loading Indicator**:
  - Included logic to add and remove a CSS class `ajax-loading` to the document body to indicate when an AJAX request is in progress.

* **Class Initialization**:
  - Created an instance of the `Dispatch` class and exported it as the default export.