### PR TITLE
Enum values serialization in Integer

### DIFF
--- a/src/Core/Db/Column/Integer.php
+++ b/src/Core/Db/Column/Integer.php
@@ -25,6 +25,7 @@ class Integer extends \ADIOS\Core\Db\Column
   {
     $column = parent::jsonSerialize();
     $column['byteSize'] = $this->byteSize;
+    $column['enumValues'] = $this->enumValues;
     return $column;
   }
 


### PR DESCRIPTION
Before, enumValues wouldn't get serialized. This pull request fixes this.

This pull request includes an update to the `jsonSerialize` method in the `Integer` class to include `enumValues` in the serialized output.

Changes to `jsonSerialize` method:

* [`src/Core/Db/Column/Integer.php`](diffhunk://#diff-63f83adbdb642d6d36b4192e50a96d609f78e9230f54fded36a3546ac5654758R28): Added `enumValues` to the serialized output of the `jsonSerialize` method.