### PR TITLE
Not inserting enumValues always

### DIFF
--- a/src/Core/Db/Column/Integer.php
+++ b/src/Core/Db/Column/Integer.php
@@ -25,7 +25,9 @@ class Integer extends \ADIOS\Core\Db\Column
   {
     $column = parent::jsonSerialize();
     $column['byteSize'] = $this->byteSize;
-    $column['enumValues'] = $this->enumValues;
+    if (count($this->enumValues) != 0) {
+      $column['enumValues'] = $this->enumValues;
+    }
     return $column;
   }
 


### PR DESCRIPTION
This pull request fixes a bug in Model.php:1227, where enumValues where of the size 0, which lead to a CASE MySQL statement without any CASEs and a direct ELSE (which is prohibitted).

This pull request includes a small change to the `jsonSerialize` method in the `src/Core/Db/Column/Integer.php` file. The change ensures that `enumValues` are only added to the serialized output if they are not empty.

* [`src/Core/Db/Column/Integer.php`](diffhunk://#diff-63f83adbdb642d6d36b4192e50a96d609f78e9230f54fded36a3546ac5654758R28-R30): Modified the `jsonSerialize` method to include `enumValues` only if they are not empty.