### PR TITLE
Save.php also returns whole submodels instead of just IDs

### DIFF
--- a/src/Controllers/Api/Record/Save.php
+++ b/src/Controllers/Api/Record/Save.php
@@ -63,12 +63,12 @@ class Save extends \ADIOS\Core\ApiController {
             case \ADIOS\Core\Model::HAS_MANY:
               foreach ($data[$relName] as $subKey => $subRecord) {
                 $subRecord = $this->recordSave($relModel, $subRecord, $idMasterRecord);
-                $savedRecord[$relName][$subKey] = (int) $subRecord['id'];
+                $savedRecord[$relName][$subKey] = $subRecord;
               }
             break;
             case \ADIOS\Core\Model::HAS_ONE:
               $subRecord = $this->recordSave($relModel, $data[$relName], $idMasterRecord);
-              $savedRecord[$relName] = (int) $subRecord['id'];
+              $savedRecord[$relName] = $subRecord;
             break;
           }
         }


### PR DESCRIPTION
This pull request includes a change to the `src/Controllers/Api/Record/Save.php` file to improve the handling of related records in the `recordSave` method.

Improvements to related record handling:

* [`src/Controllers/Api/Record/Save.php`](diffhunk://#diff-385d2ba8a2db3d6bf8191e7b78e7e3d4b6a267fdc7eaf70bd8c0d9e50aa13cbaL66-R71): Modified the `recordSave` method to store the entire sub-record instead of just the sub-record ID for both `HAS_MANY` and `HAS_ONE` relationships.