### PR TITLE
Fixed searching in lookups

### DIFF
--- a/src/Controllers/Api/Record/Lookup.php
+++ b/src/Controllers/Api/Record/Lookup.php
@@ -21,7 +21,7 @@ class Lookup extends \ADIOS\Core\ApiController {
 
     $search = $this->app->urlParamAsString('search');
     if (!empty($search)) {
-      $query->where(function($q) {
+      $query->where(function($q) use ($search) {
         foreach ($this->model->columnNames() as $columnName) {
           $q->orWhere($this->model->table . '.' . $columnName, 'LIKE', '%' . $search . '%');
         }


### PR DESCRIPTION
The closure in the method didn't use $search variable from the outer scope, resulting in search query not taking effect in lookups.

This pull request includes a small but important change to the `prepareLoadRecordQuery` method in the `Lookup` controller. The change ensures that the `$search` variable is accessible within the closure used in the `where` clause.

* [`src/Controllers/Api/Record/Lookup.php`](diffhunk://#diff-91226a2f792375c2eeca157d7c085aa0f07d858fc2672d7f2103161f9d9e19c7L24-R24): Updated the closure in the `prepareLoadRecordQuery` method to use the `$search` variable.