### PR TITLE
Fix for relation records not being deleted and fix for integrity violation of lookup columns

### DIFF
--- a/src/Core/Db/Column/Lookup.php
+++ b/src/Core/Db/Column/Lookup.php
@@ -10,7 +10,7 @@ class Lookup extends \ADIOS\Core\Db\Column
   protected string $type = 'lookup';
   protected string $sqlDataType = 'int(8)';
   protected string $lookupModel = '';
-  protected string $rawSqlDefinition = 'NULL default 0';
+  protected string $rawSqlDefinition = 'NULL default NULL';
 
   protected bool $disableForeignKey = false;
   protected string $foreignKeyColumn = 'id';

--- a/src/Core/RecordManager.php
+++ b/src/Core/RecordManager.php
@@ -273,7 +273,7 @@ class RecordManager {
         }
       }
 
-      if ((bool) ($savedRecord['_toBeDeleted_'] ?? false)) {
+      if ((bool) ($record['_toBeDeleted_'] ?? false)) {
         $this->delete((int) $savedRecord['id']);
         $savedRecord = [];
       } else if ($isCreate) {


### PR DESCRIPTION
When saving a record from a form, the table records (relation records) that were being deleted were not deleted after save.

The `_toBeDeleted_` key/value pair was being ignored likely due to this transformation of the saved record (`RecordManger.php` line 268):
```
foreach ($savedRecord as $key => $value) {
  if (!isset($columns[$key])) {
    unset($savedRecord[$key]);
  } else if ($value['_useMasterRecordId_'] ?? false) {
    $savedRecord[$key] = $idMasterRecord;
  }
}
```
