### PR TITLE
Few exception fixes

### DIFF
--- a/src/Controllers/Api/Record/Delete.php
+++ b/src/Controllers/Api/Record/Delete.php
@@ -19,6 +19,7 @@ class Delete extends \ADIOS\Core\ApiController {
   public function response(): array
   {
     $ok = false;
+    $rowsAffected = 0;
 
     if ($this->app->configAsBool('encryptRecordIds')) {
       $hash = $this->app->urlParamAsString('hash');

--- a/src/Core/Loader.php
+++ b/src/Core/Loader.php
@@ -1216,7 +1216,7 @@ class Loader
           }
         } else {
           preg_match("/Duplicate entry '(.*?)' for key '(.*?)'/", $dbError, $m);
-          $invalidColumns = [$m[2]];
+          if (!empty($m[2])) $invalidColumns = [$m[2]];
         }
 
         switch ($errorNo) {

--- a/src/Core/RecordManager.php
+++ b/src/Core/RecordManager.php
@@ -370,7 +370,7 @@ class RecordManager {
     }
 
     if (!empty($invalidInputs)) {
-      throw new RecordSaveException(json_encode($invalidInputs), 87335);
+      throw new \ADIOS\Core\Exceptions\RecordSaveException(json_encode($invalidInputs), 87335);
     }
 
     return $record;


### PR DESCRIPTION
- fixed `Delete.php` error due to `rowsAffected` not being created after a delete error
- fixed an undefined array key error, where `preg_match()` was being checked against a wrong error message resulting in the matches array being empty
- fixed unknown `RecordSaveException` class error