### PR TITLE
Master record and record delete fix

### DIFF
--- a/src/Core/Db/Column/Lookup.php
+++ b/src/Core/Db/Column/Lookup.php
@@ -61,9 +61,11 @@ class Lookup extends \ADIOS\Core\Db\Column
     } else if ($value['_isNew_'] ?? false) {
       $lookupModel = $this->model->app->getModel($this->model->getColumns()[$colName]->getLookupModel());
       return $lookupModel->eloquent->create($lookupModel->getNewRecordDataFromString($value['_LOOKUP'] ?? ''))->id;
+    } else if ($value['_useMasterRecordId_'] ?? false) {
+      return $value;
     } else if (empty($value)) {
       return null;
-    }
+    } else return null;
   }
 
   public function sqlIndexString(string $table, string $columnName): string

--- a/src/Core/Record.php
+++ b/src/Core/Record.php
@@ -282,7 +282,7 @@ class Record {
 
       if ((bool) ($record['_toBeDeleted_'] ?? false)) {
         $this->delete((int) $savedRecord['id']);
-        $savedRecord = [];
+        return [];
       } else if ($isCreate) {
         $savedRecord = $this->model->onBeforeCreate($savedRecord);
         $savedRecord = $this->create($savedRecord);


### PR DESCRIPTION
- fixed an issue where the `_useMasterRecordId_` value would be deleted during lookup column normalization, resulting in creation of a record, that was not connected to it's master record
- fixed an issue where a record deletion would cause an error due to the code wanting to continue to work with now empty record data