### PR TITLE
404 handling

### DIFF
--- a/src/Controllers/NotFound.php
+++ b/src/Controllers/NotFound.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ADIOS\Controllers;
+
+class NotFound extends \ADIOS\Core\Controller {
+  public bool $requiresUserAuthentication = false;
+  public bool $hideDefaultDesktop = true;
+
+  public function prepareView(): void
+  {
+    $this->setView('@app/Views/404.twig');
+  }
+}

--- a/src/Core/Loader.php
+++ b/src/Core/Loader.php
@@ -488,18 +488,14 @@ class Loader
       // First, try the new routing principle with httpGet
       $routeData = $this->router->parseRoute(\ADIOS\Core\Router::HTTP_GET, $this->route);
 
-      if (empty($routeData['controller'])) {
-        return '';
-      } else {
-        $this->controller = $routeData['controller'];
-        $this->permission = '';
+      $this->controller = $routeData['controller'];
+      $this->permission = '';
 
-        $routeVars = $routeData['vars'];
-        $this->router->setRouteVars($routeVars);
+      $routeVars = $routeData['vars'];
+      $this->router->setRouteVars($routeVars);
 
-        foreach ($routeVars as $varName => $varValue) {
-          $this->params[$varName] = $varValue;
-        }
+      foreach ($routeVars as $varName => $varValue) {
+        $this->params[$varName] = $varValue;
       }
 
       if ($this->isUrlParam('sign-out')) {
@@ -513,7 +509,7 @@ class Loader
 
       // Check if controller exists and if it can be used
       if (empty($this->controller)) {
-        $controllerClassName = \ADIOS\Core\Controller::class;
+        $controllerClassName = $this->router->createNotFoundController();
       } else if (!$this->controllerExists($this->controller)) {
         throw new \ADIOS\Core\Exceptions\ControllerNotFound($this->controller);
       } else {

--- a/src/Core/Router.php
+++ b/src/Core/Router.php
@@ -259,6 +259,16 @@ class Router {
     return $controller;
   }
 
+  public function createNotFoundController(): \ADIOS\Core\Controller
+  {
+    $controller = new \ADIOS\Core\Controller($this->app);
+    $controller->requiresUserAuthentication = FALSE;
+    $controller->hideDefaultDesktop = TRUE;
+    $controller->translationContext = 'ADIOS\\Core\\Loader::Controllers\\NotFound';
+    $controller->setView('@app/Views/NotFound.twig');
+    return $controller;
+  }
+
   public function createResetPasswordController(): \ADIOS\Core\Controller
   {
     return new \ADIOS\Core\Controller($this->app);

--- a/src/Lang/sk.json
+++ b/src/Lang/sk.json
@@ -51,5 +51,10 @@
         "Email": "",
         "Request password reset": "",
         "Back to sign in": ""
+    },
+    "Controllers\\NotFound": {
+        "Page Not Found": "",
+        "Sorry, we couldn’t find the page you were looking for. Please check your permissions or return to the home page.": "",
+        "Home": ""
     }
 }


### PR DESCRIPTION
This pull request introduces a new `NotFound` controller to handle 404 errors more effectively and refactors the routing logic in the `Loader` and `Router` classes to integrate this functionality. Additionally, it updates the language file to support localized messages for the new `NotFound` controller.

### New `NotFound` Controller:

* [`src/Controllers/NotFound.php`](diffhunk://#diff-d9458cf3258eaa132372eb00644f1fbcd8aecc625222e01d1dd4b1810ad73be8R1-R13): Added a new `NotFound` controller class to handle 404 errors. This controller disables user authentication requirements and hides the default desktop view, rendering a custom 404 page using the `@app/Views/404.twig` template.

### Routing Logic Refactor:

* [`src/Core/Loader.php`](diffhunk://#diff-cd113d155cb0d9b3f9d37941487fef15185e3f76352d10297b0a733b12a3f530L491-L493): Updated the `render` method to use the `createNotFoundController` method from the router when no valid controller is found, replacing the previous default behavior. This ensures a more consistent and user-friendly handling of 404 errors. [[1]](diffhunk://#diff-cd113d155cb0d9b3f9d37941487fef15185e3f76352d10297b0a733b12a3f530L491-L493) [[2]](diffhunk://#diff-cd113d155cb0d9b3f9d37941487fef15185e3f76352d10297b0a733b12a3f530L503) [[3]](diffhunk://#diff-cd113d155cb0d9b3f9d37941487fef15185e3f76352d10297b0a733b12a3f530L516-R512)
* [`src/Core/Router.php`](diffhunk://#diff-1796c9aab9b237682ebed3573d6f1adc7387254f9824356cc0e10e27903039ebR262-R271): Added a `createNotFoundController` method to instantiate and configure the new `NotFound` controller.

### Localization Support:

* [`src/Lang/sk.json`](diffhunk://#diff-96507abb6eadc8e4aa6c3293cdb038cc5ffe0f2bdf5b52d38600e86fd8eba5fbR54-R58): Added new translation keys and placeholders for messages related to the `NotFound` controller, such as "Page Not Found" and guidance for users encountering a 404 error.